### PR TITLE
Add annotations to decapode models 

### DIFF
--- a/src/amr.jl
+++ b/src/amr.jl
@@ -64,6 +64,19 @@ end
   # Stratification
 end
 
+@data Note <: AbstractTerm begin
+  Name(str::String)
+  Description(str::String)
+  Grounding(ontology::String, identifier::String)
+  Units(expression::String)
+end
+
+@as_record struct Annotation{E,T}
+  entity::E
+  type::T
+  note::Note
+end
+
 @as_record struct Header <: AbstractTerm
   name::String
   schema::String

--- a/src/amr.jl
+++ b/src/amr.jl
@@ -108,10 +108,10 @@ end
 
 function note_string(n::Note)
   @match n begin
-    Name(n)           => n
-    Description(d)    => d
-    Grounding(ont, ident) => "$ont,$ident"
-    Units(e)          => e
+    Name(n)           => "Name($n)"
+    Description(d)    => "Description($d)"
+    Grounding(ont, ident) => "Grounding($ont,$ident)"
+    Units(e)          => "Units($e)"
   end
 end
 
@@ -401,6 +401,7 @@ function load(::Type{Annotation}, ex::Expr)
       end
     end
   end |> x->filter(!isnothing, x) |> ODEList=#
+  Annotation(ex.entity,ex.type,ex.note)
 end
 
 function load(::Type{Parameter}, ex::Expr)

--- a/src/amr.jl
+++ b/src/amr.jl
@@ -12,6 +12,7 @@ using Reexport
 @reexport using ACSets
 using ACSets.ADTs
 using ACSets.ACSetInterface
+using StructTypes
 
 using ..SyntacticModelsBase
 
@@ -71,6 +72,11 @@ end
   Grounding(ontology::String, identifier::String)
   Units(expression::String)
 end
+
+StructTypes.StructType(::Type{Note}) = StructTypes.AbstractType()
+StructTypes.subtypekey(::Type{Note}) = :_type
+StructTypes.subtypes(::Type{Note}) =
+  (Name=Name,Description=Description,Grounding=Grounding,Units=Units,)
 
 @as_record struct Annotation{E,T} <: AbstractTerm
   entity::E
@@ -146,7 +152,7 @@ function amr_to_string(amr)
       xs::Vector                       => map(!, xs)
       Typing(system, map)              => "Typing = begin\n$(padlines(!system, 2))\nTypeMap = [\n$(padlines(!map, 2))]\nend"
       ASKEModel(h, m, s)               => "$(!h)\n$(!m)\n\n$(!s)"
-      Annotation(e,t,n)                => "Annotation = $e,$t: $(note_string(n))"
+      Annotation(e,t,n)                => "Annotation = $(String(e)),$(String(t)): $(note_string(n))"
     end
   end
 end
@@ -183,7 +189,7 @@ function amr_to_expr(amr)
       xs::Vector                       => begin ys = map(!, xs); block(ys) end
       Typing(system, map)              => :(Typing = $(!system); TypeMap = $(block(map)))
       ASKEModel(h, m, s)               => :($(!h);$(!m);$(!s))
-      Annotation(e,t,n)                => "Annotation = $e,$t: $(note_expr(n))"
+      Annotation(e,t,n)                => "Annotation = $(String(e)),$(String(t)): $(note_expr(n))"
     end
   end
 end

--- a/src/amr.jl
+++ b/src/amr.jl
@@ -378,38 +378,6 @@ function load(d::Type{Distribution}, ex::Expr)
   end
 end
 
-function load(::Type{Note}, ex::Expr)
-  @matchast ex quote
-    Name($n) => Name(n)
-    Description($d) => Description(d) 
-    Grounding($ont,$ident) => Grounding(ont,ident)
-    Units($e) => Units(e)
-  end
-end
-
-function load(::Type{Annotation}, ex::Expr)
- #= map(ex.args[2].args) do arg
-    try 
-      return load(Rate, arg)
-    catch ErrorException 
-      try 
-        return load(Initial, arg)
-      catch ErrorException 
-        try 
-          return load(Parameter, arg)
-        catch ErrorException 
-          try 
-            return load(Time, arg)
-          catch
-            return nothing
-          end
-        end
-      end
-    end
-  end |> x->filter(!isnothing, x) |> ODEList=#
-  Annotation(ex.entity,ex.type,ex.note)
-end
-
 function load(::Type{Parameter}, ex::Expr)
   name, desc, ex = docval(ex)
   id, u, val, dist = @matchast ex quote

--- a/src/decapodes.jl
+++ b/src/decapodes.jl
@@ -10,8 +10,8 @@ using Decapodes
 using MLStyle
 
 @data ASKEMDeca <: AbstractTerm begin
-  ASKEMDecaExpr(header::AMR.Header, model::Decapodes.DecaExpr)
-  ASKEMDecapode(header::AMR.Header, model::Decapodes.SummationDecapode)
+  ASKEMDecaExpr(header::AMR.Header, model::Decapodes.DecaExpr, annotations::Vector{AMR.Annotation{Symbol,Symbol}})
+  ASKEMDecapode(header::AMR.Header, model::Decapodes.SummationDecapode, annotations::Vector{AMR.Annotation{Symbol,Symbol}})
 end
 
 @doc """    ASKEMDeca
@@ -25,14 +25,14 @@ ASKEMDeca
 Stores the syntactic expression of a Decapode Expression with the
 model metadata for ASKEM AMR conformance.
 """
-ASKEMDecaExpr
+ASKEMDecaExpr(header::AMR.Header, model::Decapodes.DecaExpr) = ASKEMDecaExpr(header,model,Vector{AMR.Annotation{Symbol,Symbol}}())
 
 @doc """    ASKEMDecapode
 
 Stores the combinatorial representation of a Decapode with the
 model metadata for ASKEM AMR conformance.
 """
-ASKEMDecapode
+ASKEMDecapode(header::AMR.Header, model::Decapodes.SummationDecapode) = ASKEMDecapode(header,model,Vector{AMR.Annotation{Symbol,Symbol}}())
 
 StructTypes.StructType(::Type{ASKEMDeca}) = StructTypes.AbstractType()
 StructTypes.subtypekey(::Type{ASKEMDeca}) = :_type

--- a/test/decapodes_examples.jl
+++ b/test/decapodes_examples.jl
@@ -32,8 +32,10 @@ dexpr = Decapodes.parse_decapode(quote
 end
 )
 
+annot = [AMR.Annotation(:X,:Form0,AMR.Name("The X variable."))]
+
 # Bundle the DecaExpr with the header metadata.
-mexpr = ASKEMDecaExpr(h, dexpr)
+mexpr = ASKEMDecaExpr(h, dexpr, annot)
 
 # Convert a the DecaExpr to a SummationDecapode which is the
 # combinatorial representation. The converter lives in Decapodes/src/language.jl.
@@ -51,7 +53,7 @@ h = AMR.Header("harmonic_oscillator",
   "A Simple Harmonic Oscillator as a Diagrammatic Equation",
   "SummationDecapode",
   "v1.0")
-mpode = ASKEMDecapode(h, d)
+mpode = ASKEMDecapode(h, d, annot)
 
 
 # The syntactic representation can be serialized as JSON.


### PR DESCRIPTION
This is a wip to include additional model information and annotations into decapodes models.

resolves #22 