### PR TITLE
fix: update docstring headers with correct @relation syntax

### DIFF
--- a/src/uwd.jl
+++ b/src/uwd.jl
@@ -58,7 +58,7 @@ Example
 
 To specify the following relation macro:
 ```julia
-@relation (x:X, z:Z) where y:Y begin
+@relation (x, z) where (x::X, y::Y, z::Z, u::U) begin
   R(x,y)
   S(y,z)
   T(z,y,u)

--- a/test/uwd_examples.jl
+++ b/test/uwd_examples.jl
@@ -12,7 +12,7 @@ using Catlab.Graphics
 # This example follows what in current catlab would be given as
 
 #=
-@relation (x:X, z:Z) where y:Y begin
+@relation (x, z) where (x::X, y::Y, z::Z, u::U) begin
   R(x,y)
   S(y,z)
   T(z,y,u)


### PR DESCRIPTION
The headers referenced this code:
```
@relation (x:X, z:Z) where y:Y begin
  R(x,y)
  S(y,z)
  T(z,y,u)
end
```
which had several errors if the user decides to actually run them. This PR fixes those errors so the code is usable.